### PR TITLE
fix: catch error in batchResult handler

### DIFF
--- a/packages/execution/test/fallback-provider.spec.ts
+++ b/packages/execution/test/fallback-provider.spec.ts
@@ -10,6 +10,7 @@ import {
   fakeFetchImplThatAlwaysFails,
   fakeFetchImplThatCanOnlyDoNetworkDetection,
   fixtures,
+  makeFakeFetchImplReturnsNull,
   makeFakeFetchImplThatFailsAfterNRequests,
   makeFakeFetchImplThatFailsFirstNRequests,
   makeFakeFetchImplThrowsError,
@@ -413,6 +414,29 @@ describe('Execution module. ', () => {
       ).rejects.toThrow(
         "Fallback provider [1] network is different to other provider's networks",
       );
+
+      mockedNetworksEqual.mockReset();
+    });
+
+    test('should not fail on malformed response from RPC', async () => {
+      await createMocks(2);
+
+      const mockedNetworksEqual = jest
+        .spyOn(mockedProvider, 'networksEqual')
+        .mockImplementation((): boolean => {
+          return true;
+        });
+
+      mockedFallbackProviderFetch[0].mockImplementation(
+        makeFakeFetchImplReturnsNull(),
+      );
+
+      mockedFallbackProviderFetch[1].mockImplementation(
+        makeFetchImplWithSpecificNetwork(1),
+      );
+
+      const block = await mockedProvider.getBlock('latest');
+      expect(block.number).toBe(10000);
 
       mockedNetworksEqual.mockReset();
     });

--- a/packages/execution/test/fixtures/fake-json-rpc.ts
+++ b/packages/execution/test/fixtures/fake-json-rpc.ts
@@ -271,6 +271,12 @@ export const makeFakeFetchImplThrowsError = (error: Error) => {
   };
 };
 
+export const makeFakeFetchImplReturnsNull = () => {
+  return async (): Promise<unknown> => {
+    return null;
+  };
+};
+
 export const fakeFetchImplThatAlwaysFails = async (): Promise<never> => {
   throw new Error('Always fail');
 };


### PR DESCRIPTION
When the provider returns e.g. empty response, `batchResult`'s handler fails and is not caught anywhere which may cause the application to crash on unhandled promise rejection.