### PR TITLE
fix: CALL_EXCEPTION server errors handling 

### DIFF
--- a/packages/execution/src/common/errors.ts
+++ b/packages/execution/src/common/errors.ts
@@ -79,10 +79,20 @@ export const nonRetryableErrors: (string | number)[] = [
 ];
 
 export type ErrorWithCode = Error & { code: number | string };
+export type ServerError = ErrorWithCode & { serverError: object };
 
 export const isErrorHasCode = (error: unknown): error is ErrorWithCode => {
   return (
     error instanceof Error &&
     Object.prototype.hasOwnProperty.call(error, 'code')
+  );
+};
+
+export const isCallExceptionServerError = (
+  error: ErrorWithCode,
+): error is ServerError => {
+  return (
+    error.code === ErrorCode.CALL_EXCEPTION &&
+    Object.prototype.hasOwnProperty.call(error, 'serverError')
   );
 };

--- a/packages/execution/src/provider/simple-fallback-json-rpc-batch-provider.ts
+++ b/packages/execution/src/provider/simple-fallback-json-rpc-batch-provider.ts
@@ -18,7 +18,11 @@ import {
 } from '../common/networks';
 import { EventType, Listener } from '@ethersproject/abstract-provider';
 import { NoNewBlocksWhilePollingError } from '../error/no-new-blocks-while-polling.error';
-import { isErrorHasCode, nonRetryableErrors } from '../common/errors';
+import {
+  isErrorHasCode,
+  isCallExceptionServerError,
+  nonRetryableErrors,
+} from '../common/errors';
 import { AllProvidersFailedError } from '../error/all-providers-failed.error';
 import { FeeHistory, getFeeHistory } from '../ethers/fee-history';
 
@@ -203,7 +207,11 @@ export class SimpleFallbackJsonRpcBatchProvider extends BaseProvider {
   }
 
   protected errorShouldBeReThrown(error: Error | unknown): boolean {
-    return isErrorHasCode(error) && nonRetryableErrors.includes(error.code);
+    return (
+      isErrorHasCode(error) &&
+      nonRetryableErrors.includes(error.code) &&
+      !isCallExceptionServerError(error)
+    );
   }
 
   public async perform(

--- a/packages/execution/test/fallback-provider.spec.ts
+++ b/packages/execution/test/fallback-provider.spec.ts
@@ -709,10 +709,10 @@ describe('Execution module. ', () => {
       // to ensure the second provider is active
       await mockedProvider.getBlock(10000);
 
-      // 'getBlock' fetch
+      // no second 'getBlock' fetch
       expect(mockedFallbackProviderFetch[0]).toBeCalledTimes(1);
 
-      // 'getBlock' fetch call to second provider that does not fail
+      // second 'getBlock' fetch call to second provider that does not fail
       expect(mockedFallbackProviderFetch[1]).toBeCalledTimes(2);
     });
   });


### PR DESCRIPTION
CALL_EXCEPTION server errors that occur because of server errors will now trigger switching to another provider