### PR TITLE
fix: fix block`s subscription in execution provider

### DIFF
--- a/packages/execution/src/provider/simple-fallback-json-rpc-batch-provider.ts
+++ b/packages/execution/src/provider/simple-fallback-json-rpc-batch-provider.ts
@@ -148,7 +148,7 @@ export class SimpleFallbackJsonRpcBatchProvider extends BaseProvider {
     if (eventName === 'block') {
       startDieTimer(-1);
 
-      super.on(eventName, function (this: unknown, ...args) {
+      return super.on(eventName, function (this: unknown, ...args) {
         startDieTimer(args[0]);
         return listener.apply(this, args);
       });

--- a/packages/execution/test/fallback-provider-polling.spec.ts
+++ b/packages/execution/test/fallback-provider-polling.spec.ts
@@ -105,11 +105,30 @@ describe('Execution module. ', () => {
         (err) => err instanceof NoNewBlocksWhilePollingError,
       );
 
-      expect(listenerMock).toBeCalledTimes(2);
+      expect(listenerMock).toBeCalledTimes(1);
       expect(errors.length).toBe(1);
       expect(noNewBlocksErrors.length).toBe(1);
 
       mockedProvider.removeAllListeners();
+    });
+
+    it('should call listener 1 time without errors', async () => {
+      const errors: Error[] = [];
+      const listener = jest.fn();
+      const blockNumber = 12345;
+
+      mockedProvider.on('block', listener);
+      mockedProvider.on('error', (err) => errors.push(err));
+      expect(listener).not.toHaveBeenCalled();
+
+      // Emit a block event
+      mockedProvider.emit('block', blockNumber);
+      await sleep(10);
+
+      // Ensure that the listener was called with the correct arguments
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(blockNumber);
+      expect(errors.length).toBe(0);
     });
   });
 });

--- a/packages/execution/test/fallback-provider-polling.spec.ts
+++ b/packages/execution/test/fallback-provider-polling.spec.ts
@@ -129,6 +129,8 @@ describe('Execution module. ', () => {
       expect(listener).toHaveBeenCalledTimes(1);
       expect(listener).toHaveBeenCalledWith(blockNumber);
       expect(errors.length).toBe(0);
+
+      mockedProvider.removeAllListeners();
     });
   });
 });


### PR DESCRIPTION
Fixed an issue where block subscription would create 2 subscriptions and listener to be called 2 times per emit.