### PR TITLE
Update blst ssz library to 2.2.0, 0.18.0 versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --immutable

--- a/packages/key-validation/package.json
+++ b/packages/key-validation/package.json
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@chainsafe/blst": "0.2.4",
-    "@chainsafe/ssz": "0.9.2",
+    "@chainsafe/blst": "^2.2.0",
+    "@chainsafe/ssz": "^0.18.0",
     "@lido-nestjs/constants": "workspace:*",
     "@lido-nestjs/contracts": "workspace:*",
     "@lido-nestjs/di": "workspace:*",

--- a/packages/key-validation/src/common/validate-one-key.ts
+++ b/packages/key-validation/src/common/validate-one-key.ts
@@ -3,7 +3,7 @@ import { bufferFromHexString } from './buffer-hex';
 import { computeDomain } from './domain';
 import { computeSigningRoot } from './compute-signing-root';
 import { DepositMessage } from '../ssz';
-import { CoordType, PublicKey, Signature, verify } from '@chainsafe/blst';
+import { PublicKey, Signature, verify } from '@chainsafe/blst';
 import { Pubkey, WithdrawalCredentialsBuffer } from '../interfaces';
 import { getDepositMessage } from './deposit';
 
@@ -33,8 +33,8 @@ export const validateOneKey = (
   try {
     return verify(
       signingRoot,
-      PublicKey.fromBytes(pubkeyBuffer, CoordType.affine),
-      Signature.fromBytes(signatureBuffer, CoordType.affine),
+      PublicKey.fromBytes(pubkeyBuffer, true),
+      Signature.fromBytes(signatureBuffer, true),
     );
   } catch (e) {
     return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,40 +416,149 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainsafe/as-sha256@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "@chainsafe/as-sha256@npm:0.3.1"
-  checksum: 58ea733be1657b0e31dbf48b0dba862da0833df34a81c1460c7352f04ce90874f70003cbf34d0afb9e5e53a33ee2d63a261a8b12462be85b2ba0a6f7f13d6150
+"@chainsafe/as-sha256@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@chainsafe/as-sha256@npm:0.5.0"
+  checksum: e9dc541fe43bd4172516a55a636390fbae74d54360acba6f46b84ab0fb6a6b1a4f71a950d80d553546a165873454f2f71cb98a3c4b9f73b25d6723cd2fc9f910
   languageName: node
   linkType: hard
 
-"@chainsafe/blst@npm:0.2.4":
-  version: 0.2.4
-  resolution: "@chainsafe/blst@npm:0.2.4"
-  dependencies:
-    node-fetch: ^2.6.1
-    node-gyp: ^8.4.0
-  checksum: eae72b91e7472bf1e300f02b5be6dbb70eb523fb3a2777268ed8b681966252e509c9eb82b7f4b91b6435929e0f424ac2f39c690be9fee6b0237ea47834bd5bb7
+"@chainsafe/blst-darwin-arm64@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainsafe/blst-darwin-arm64@npm:2.2.0"
+  conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@chainsafe/persistent-merkle-tree@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "@chainsafe/persistent-merkle-tree@npm:0.4.2"
-  dependencies:
-    "@chainsafe/as-sha256": ^0.3.1
-  checksum: f9cfcb2132a243992709715dbd28186ab48c7c0c696f29d30857693cca5526bf753974a505ef68ffd5623bbdbcaa10f9083f4dd40bf99eb6408e451cc26a1a9e
+"@chainsafe/blst-darwin-x64@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainsafe/blst-darwin-x64@npm:2.2.0"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@chainsafe/ssz@npm:0.9.2":
-  version: 0.9.2
-  resolution: "@chainsafe/ssz@npm:0.9.2"
+"@chainsafe/blst-linux-arm64-gnu@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainsafe/blst-linux-arm64-gnu@npm:2.2.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@chainsafe/blst-linux-arm64-musl@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainsafe/blst-linux-arm64-musl@npm:2.2.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@chainsafe/blst-linux-x64-gnu@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainsafe/blst-linux-x64-gnu@npm:2.2.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@chainsafe/blst-linux-x64-musl@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainsafe/blst-linux-x64-musl@npm:2.2.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@chainsafe/blst-win32-x64-msvc@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@chainsafe/blst-win32-x64-msvc@npm:2.2.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@chainsafe/blst@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@chainsafe/blst@npm:2.2.0"
   dependencies:
-    "@chainsafe/as-sha256": ^0.3.1
-    "@chainsafe/persistent-merkle-tree": ^0.4.2
-    case: ^1.6.3
-  checksum: 639edfb35e45afceab0c2c485e340733daad5d5a397d623288db141079cbaec9341fa477cd42b140323bd598c74cb78ada11f7c7638fdd164741703e045c2cb7
+    "@chainsafe/blst-darwin-arm64": 2.2.0
+    "@chainsafe/blst-darwin-x64": 2.2.0
+    "@chainsafe/blst-linux-arm64-gnu": 2.2.0
+    "@chainsafe/blst-linux-arm64-musl": 2.2.0
+    "@chainsafe/blst-linux-x64-gnu": 2.2.0
+    "@chainsafe/blst-linux-x64-musl": 2.2.0
+    "@chainsafe/blst-win32-x64-msvc": 2.2.0
+  dependenciesMeta:
+    "@chainsafe/blst-darwin-arm64":
+      optional: true
+    "@chainsafe/blst-darwin-x64":
+      optional: true
+    "@chainsafe/blst-linux-arm64-gnu":
+      optional: true
+    "@chainsafe/blst-linux-arm64-musl":
+      optional: true
+    "@chainsafe/blst-linux-x64-gnu":
+      optional: true
+    "@chainsafe/blst-linux-x64-musl":
+      optional: true
+    "@chainsafe/blst-win32-x64-msvc":
+      optional: true
+  checksum: df48f06c0126cd04ac3e59d745ccdc47e4071c06c2edfb6edee9d13f8c178d1c3e48476852bc316df347651bbaac5cbe870345e5cb66ac5753ae00a3a6ce674b
+  languageName: node
+  linkType: hard
+
+"@chainsafe/hashtree-darwin-arm64@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@chainsafe/hashtree-darwin-arm64@npm:1.0.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@chainsafe/hashtree-linux-arm64-gnu@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@chainsafe/hashtree-linux-arm64-gnu@npm:1.0.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@chainsafe/hashtree-linux-x64-gnu@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@chainsafe/hashtree-linux-x64-gnu@npm:1.0.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@chainsafe/hashtree@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@chainsafe/hashtree@npm:1.0.1"
+  dependencies:
+    "@chainsafe/hashtree-darwin-arm64": 1.0.1
+    "@chainsafe/hashtree-linux-arm64-gnu": 1.0.1
+    "@chainsafe/hashtree-linux-x64-gnu": 1.0.1
+  dependenciesMeta:
+    "@chainsafe/hashtree-darwin-arm64":
+      optional: true
+    "@chainsafe/hashtree-linux-arm64-gnu":
+      optional: true
+    "@chainsafe/hashtree-linux-x64-gnu":
+      optional: true
+  checksum: 4e4f0dda972cf872b38afd51104db294d7da870da6a73588566465c4dfefd4dc8aa284c513827cc3714c692dbcdb6a92fd9c32e5a99894164ad1228c2602b0bb
+  languageName: node
+  linkType: hard
+
+"@chainsafe/persistent-merkle-tree@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@chainsafe/persistent-merkle-tree@npm:0.8.0"
+  dependencies:
+    "@chainsafe/as-sha256": 0.5.0
+    "@chainsafe/hashtree": 1.0.1
+    "@noble/hashes": ^1.3.0
+  checksum: 8d04ab0fcd8edbb77eb4362e7325a3bf1432986f827b5c5fa84a3710a687607a67e7095afb5fe071ef33faaa7104a5ab5223127299bfe08a565e2f203ca4e34a
+  languageName: node
+  linkType: hard
+
+"@chainsafe/ssz@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "@chainsafe/ssz@npm:0.18.0"
+  dependencies:
+    "@chainsafe/as-sha256": 0.5.0
+    "@chainsafe/persistent-merkle-tree": 0.8.0
+  checksum: 7ff2758005d57513ff2ff1a898964e0b962cb16703836d6647b2cbce3379dae554101eff1b9dc3f907d8e8be5169459f725fd3b8682cf0fec37382b4bde8e883
   languageName: node
   linkType: hard
 
@@ -2649,8 +2758,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lido-nestjs/key-validation@workspace:packages/key-validation"
   dependencies:
-    "@chainsafe/blst": 0.2.4
-    "@chainsafe/ssz": 0.9.2
+    "@chainsafe/blst": ^2.2.0
+    "@chainsafe/ssz": ^0.18.0
     "@ethersproject/providers": ^5.5.3
     "@lido-nestjs/constants": "workspace:*"
     "@lido-nestjs/contracts": "workspace:*"
@@ -3142,6 +3251,13 @@ __metadata:
     "@nestjs/platform-express":
       optional: true
   checksum: 03c78066aac242b282a0621eff137ad1574a3a92f47d08d2e643312b55b33865bbb8e779c58bfdae4875b7afb6d6e06108f81cece1fe3a5a2451ee334de49a0a
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.3.0":
+  version: 1.6.1
+  resolution: "@noble/hashes@npm:1.6.1"
+  checksum: 57c62f65ee217c0293b4321b547792aa6d79812bfe70a7d62dc83e0f936cc677b14ed981b4e88cf8fdad37cd6d3a0cbd3bd0908b0728adc9daf066e678be8901
   languageName: node
   linkType: hard
 
@@ -5669,13 +5785,6 @@ __metadata:
   bin:
     cdl: ./bin/cdl.js
   checksum: e8d4ae46439cf8fed481c0efd267711ee91e199aa7821a9143e784ed94a6495accd01a0b36d84d377e8ee2cc9928a6c9c123b03be761c60b805f2c026b8a99ad
-  languageName: node
-  linkType: hard
-
-"case@npm:^1.6.3":
-  version: 1.6.3
-  resolution: "case@npm:1.6.3"
-  checksum: febe73278f910b0d28aab7efd6f51c235f9aa9e296148edb56dfb83fd58faa88308c30ce9a0122b6e53e0362c44f4407105bd5ef89c46860fc2b184e540fd68d
   languageName: node
   linkType: hard
 
@@ -12678,7 +12787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:8.x, node-gyp@npm:^8.4.0, node-gyp@npm:latest":
+"node-gyp@npm:8.x, node-gyp@npm:latest":
   version: 8.4.1
   resolution: "node-gyp@npm:8.4.1"
   dependencies:


### PR DESCRIPTION
BREAKING CHANGE: blst lib require node version >= 16