### PR TITLE
fix(key-validation): get rid of spread operator in push

### DIFF
--- a/packages/key-validation/src/services/lido-key-validator.ts
+++ b/packages/key-validation/src/services/lido-key-validator.ts
@@ -40,7 +40,7 @@ export class LidoKeyValidator implements LidoKeyValidatorInterface {
     }
 
     const keysByModule = this.groupKeysByModule(lidoKeys);
-    const results: [Key & LidoKey & T, boolean][] = [];
+    let results: [Key & LidoKey & T, boolean][] = [];
 
     for (const [moduleId, moduleKeys] of keysByModule) {
       const possibleWC =
@@ -49,7 +49,7 @@ export class LidoKeyValidator implements LidoKeyValidatorInterface {
         moduleKeys,
         possibleWC,
       );
-      results.push(...moduleResults);
+      results = results.concat(moduleResults);
     }
 
     return results;


### PR DESCRIPTION
There was a bug in the `validateKeys` method. When the module has very many keys (more than 100K), the spread operator in this construction `results.push(...moduleResults)` unwraps all `moduleResults` keys to the arguments of the `push` method. This leads to hundreds of thousands of arguments passed to the `push` method, and it leads to a stack overflow. This commit fixes this bug.